### PR TITLE
Patch for kenels >= 5.0 (#46)

### DIFF
--- a/Driver/enhanceio/compat.h
+++ b/Driver/enhanceio/compat.h
@@ -42,6 +42,9 @@
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0))
 #define COMPAT_NO_BIO_BIDEV
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0))
+#define COMPAT_GET_KTIME
+#endif
 
 /*Include features backported to RedHat kernels*/
 #ifdef RHEL_RELEASE_CODE
@@ -333,4 +336,12 @@ static inline struct block_device *blkdev_get_by_path(const char *path, fmode_t 
 #define EIO_BIO_COPY_DEV(DEST, SRC) \
 	do { (DEST)->bi_bdev = (SRC)->bi_bdev; } while (0)
 #define EIO_BIO_GET_QUEUE(bio) bdev_get_queue((bio)->bi_bdev)
+#endif
+
+#ifdef COMPAT_GET_KTIME
+#define GET_KTIME(time) ktime_get_real_ts64(time)
+#define TIME_STRUCT timespec64
+#else
+#define GET_KTIME(time) do_gettimeofday(time)
+#define TIME_STRUCT timeval
 #endif

--- a/Driver/enhanceio/eio.h
+++ b/Driver/enhanceio/eio.h
@@ -1,5 +1,4 @@
-/*
- *  eio.h
+/*  eio.h
  *
  *  Copyright (C) 2012 STEC, Inc. All rights not specifically granted
  *   under a license included herein are reserved
@@ -758,7 +757,7 @@ struct cache_c {
 	struct eio_stats eio_stats;     /* Run time stats */
 	struct eio_errors eio_errors;   /* Error stats */
 	int countErrors[COUNT_SECONDS]; /* Count errors in last N secconds*/
-	struct timeval lasttime;
+	struct TIME_STRUCT lasttime;
 	int clean_inprog;
 	atomic64_t nr_dirty;
 	atomic64_t nr_ios;

--- a/Driver/enhanceio/eio_main.c
+++ b/Driver/enhanceio/eio_main.c
@@ -369,7 +369,7 @@ static void eio_post_io_callback(struct work_struct *work)
 	unsigned eb_cacheset;
 	u_int8_t cstate;
 	int callendio = 0;
-	struct timeval curtime;
+	struct TIME_STRUCT curtime;
 	int error;
 
 	job = container_of(work, struct kcached_job, work);
@@ -389,7 +389,7 @@ static void eio_post_io_callback(struct work_struct *work)
 		       error,
 		       (unsigned long long)job->job_io_regions.disk.sector,
 		       job->action, dmc->countErrors[0]);
-		do_gettimeofday(&curtime);
+		GET_KTIME(&curtime);
 		if(curtime.tv_sec >= dmc->lasttime.tv_sec + COUNT_SECONDS)  {
 			memset(&dmc->countErrors, 0, sizeof(dmc->countErrors));
 		} else if(curtime.tv_sec > dmc->lasttime.tv_sec)  {

--- a/Install-EIO
+++ b/Install-EIO
@@ -1,0 +1,266 @@
+#!/bin/bash
+# A script to simplify the instalation of EnhanceIO.
+#
+# Courtesy of T. "Luna" Ericson aka. CPT Gray Wolf and FSG,
+# and distributed under the GPL along with EnhanceIO.
+
+# Get the script command security prefix to esure no malicious
+# scripts are executed by mistake.
+if [ -d /usr/bin ]
+    then
+    BPREFIX='/usr/bin/'
+    SBPREFIX='/usr/sbin/'
+else
+    BPREFIX='/bin/'
+    SBPREFIX='/sbin/'
+fi
+
+
+# Ensure that we're running as root.
+if [ $(${BPREFIX}id -u) -ne 0 ]
+    then
+    ${BPREFIX}echo "INSTALL-EIO: You need to be root to do that" >&2
+    exit 1
+fi
+
+
+# This is where any important preset variables will go.
+PYTHON_VERSION=$(${BPREFIX}python -c 'import platform; python_version=platform.python_version(); print (python_version)')
+SOURCE_DIR='./Driver/enhanceio/'
+KERNEL_VERSION=''
+PY_VERSION_CHECK=1; MAKE_MODS=1; INSTALL_MODS=1; CLEANUP=1; INSTALL_CLI=1; LOAD_MODS=1
+
+
+
+# Use a complicated regex to check the installed python version.
+_CheckPythonVersion ()
+{
+    if [[ "$PYTHON_VERSION" =~ ^2\.(6\.([6-9]|[1-9][0-9]+)|([7-9]|[1-9][0-9]+)\.[0-9]+)(rc[0-9]+)?$ ]]
+        then 
+        return 0
+    fi
+    return 1
+}
+
+# Install the command line interface.
+_InstallCLI ()
+{
+    if [ -e ./CLI/eio_cli ] && [ -e ./CLI/eio_cli.8 ]
+        then
+        (${BPREFIX}install -o root -g root -m 700 -D ./CLI/eio_cli /sbin/eio_cli > /dev/null 2>&1) &&
+        (${BPREFIX}install -o root -g root -m 644 -D ./CLI/eio_cli.8 /usr/share/man/man8/eio_cli.8 > /dev/null 2>&1) &&
+        return 0
+        return 2
+    fi
+    return 1
+}
+
+# Run make and build the EnhanceIO modules.
+_RunMake ()
+{
+    if ! [ -z "$1" ]
+        then
+        (cd ${SOURCE_DIR} && ${BPREFIX}make KERNEL_SOURCE_VERSION=${1} > /dev/null) &&
+        return 0
+    else
+        (cd ${SOURCE_DIR} && ${BPREFIX}make > /dev/null) &&
+        return 0
+    fi
+    return 1
+}
+
+# Run make install for the EnhanceIO modules.
+_RunInstall ()
+{ 
+    if ! [ -z "$1" ]
+        then
+        (cd ${SOURCE_DIR} && ${BPREFIX}make install KERNEL_SOURCE_VERSION=${1} > /dev/null) &&
+        return 0
+    else
+        (cd ${SOURCE_DIR} && ${BPREFIX}make install > /dev/null) &&
+        return 0
+    fi
+    return 1
+}
+
+# Cleanup files after make.
+_RunCleanup ()
+{
+    ${BPREFIX}rm -f "${SOURCE_DIR}*.?(k)o"
+    ${BPREFIX}rm -f "${SOURCE_DIR}*.mod.c"
+    ${BPREFIX}rm -f "${SOURCE_DIR}.*.cmd"
+    ${BPREFIX}rm -f "${SOURCE_DIR}*.symvers"
+    ${BPREFIX}rm -f "${SOURCE_DIR}*.order"
+    ${BPREFIX}rm -fr "${SOURCE_DIR}.tmp*"
+    return
+}
+
+# Load the EnhanceIO modules.
+_LoadMods ()
+{
+    ${SBPREFIX}modprobe enhanceio &&
+    ${SBPREFIX}modprobe enhanceio_rand &&
+    ${SBPREFIX}modprobe enhanceio_fifo &&
+    ${SBPREFIX}modprobe enhanceio_lru &&
+    return 0
+    return 1
+}
+
+#Display help options.
+_DisplayHelp ()
+{
+    ${BPREFIX}echo -e "EnhanceIO Installation Script\n"
+    ${BPREFIX}echo -e "Command options:\n"
+    ${BPREFIX}echo "      cleanup           Remove files leftover from build process."
+    ${BPREFIX}echo "      install-cli       Install the eio_cli utility, and it's manual."
+    ${BPREFIX}echo "      --help            Display help."
+    ${BPREFIX}echo "   -k --kernel-version  Chose what kernel version to compile for. Requires the"
+    ${BPREFIX}echo "                        target kernel headers to be installed."
+    ${BPREFIX}echo "   -m --no-build        Don't build the kernel modules."
+    ${BPREFIX}echo "   -i --no-install      Don't install kernel modules."
+    ${BPREFIX}echo "   -p --no-py-check     Don't check the installed python version. Has no effect"
+    ${BPREFIX}echo "                        if --kernel-version or --no-cli are set."
+    ${BPREFIX}echo "   -c --no-cli          Don't install eio_cli utility or manual. Has no effect"
+    ${BPREFIX}echo "                        if --kernel-version is set."
+    ${BPREFIX}echo "   -l --no-load         Don't load kernel modules after installation. Has no"
+    ${BPREFIX}echo "                        effect if --kernel-version is set."
+    ${BPREFIX}echo -e "   -r --no-cleanup      Don't run cleanup after building kernel modules.\n"
+    return
+}
+
+
+# Setup some shortcuts.
+if [ $# -eq 1 ]
+    then
+    case "$1" in
+        cleanup)
+        _RunCleanup
+        ${BPREFIX}echo "INSTALL-EIO: Cleaning up leftover build files"
+        exit 0
+        ;;
+        install-cli)
+        _CheckPythonVersion &&
+        _InstallCLI &&
+        exit 0
+        ${BPREFIX}echo "INSTALL-EIO: Failed to install eio_cli!" >&2
+        ;;
+        --help)
+        _DisplayHelp
+        exit 0
+        ;;
+    esac
+fi
+
+# Main program.
+while ! [ -z "$1" ]
+    do
+    case "$1" in
+      -k|--kernel-version)
+        shift
+        if ! [[ "$1" =~ ^(3\.([7-9]|[1-9][0-9]+)|([4-9]|[1-9][0-9]+)\.[0-9]+)....*$ ]]
+            then
+            ${BPREFIX}echo "INSTALL-EIO: Specified kernel is invalid or too old!" >&2
+            exit 1
+        else
+            KERNEL_VERSION="$1"
+            LOAD_MODS=0
+            PY_VERSION_CHECK=0
+            INSTALL_CLI=0
+            ${BPREFIX}echo "INSTALL-EIO: Modules will be build and installed for kernel $1"
+        fi
+        ;;
+      -r|--no-clean)
+        CLEANUP=0
+        ;;
+      -p|--no-py-check)
+        PY_VERSION_CHECK=0
+        ;;
+      -c|--no-cli)
+        PY_VERSION_CHECK=0
+        INSTALL_CLI=0
+        ;;
+      -i|--no-install)
+        INSTALL_MODS=0
+        ;;
+      -m|--no-build)
+        MAKE_MODS=0
+        ;;
+      -l|--no-load)
+        LOAD_MODS=0
+        ;;
+      *)
+        ${BPREFIX}echo "INSTALL-EIO: Argument not understood \"$1\"" >&2
+        ${BPREFIX}echo "INSTALL-EIO: Try running \"Install-EIO --help\""
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+if [ $MAKE_MODS -eq 1 ]
+    then
+    ${BPREFIX}echo "INSTALL-EIO: Building kernel modules"
+    _RunMake $KERNEL_VERSION
+    if [ $? -eq 1 ]
+        then
+        ${BPREFIX}echo "INSTALL-EIO: Failed to build modules!" >&2
+        ${BPREFIX}echo "INSTALL-EIO: Try running \"Install-EIO cleanup\" to remove any leftover files"
+        exit 1
+    fi
+fi
+if [ $INSTALL_MODS -eq 1 ]
+    then
+    ${BPREFIX}echo "INSTALL-EIO: Installing modules"
+    _RunInstall $KERNEL_VERSION
+    if [ $? -eq 1 ]
+        then
+        ${BPREFIX}echo "INSTALL-EIO: Failed to install modules!" >&2
+        exit 1
+    fi
+fi
+if [ $PY_VERSION_CHECK -eq 1 ]
+    then
+    ${BPREFIX}echo "INSTALL-EIO: Checking Python version"
+    _CheckPythonVersion
+    if [ $? -eq 1 ]
+        then
+        ${BPREFIX}echo "INSTALL-EIO: Python version is $PYTHON_VERSION, eio_cli requires python2 version 2.6.6 or higher!" >&2
+        ${BPREFIX}echo "INSTALL-EIO: eio_cli will not be installed" >&2
+        INSTALL_CLI=0
+    else
+        ${BPREFIX}echo "INSTALL-EIO: Python version is $PYTHON_VERSION"
+    fi
+fi
+if [ $INSTALL_CLI -eq 1 ]
+    then
+    ${BPREFIX}echo "INSTALL-EIO: Installing eio_cli"
+    _InstallCLI
+    if [ $? -eq 1 ]
+        then
+        ${BPREFIX}echo "INSTALL-EIO: Could not fild eio_cli files!" >&2
+        ${BPREFIX}echo "INSTALL-EIO: Failed to  install eio_cli!" >2&
+    elif [ $? -eq 2 ]
+        then
+        ${BPREFIX}echo "INSTALL-EIO: Failed to  install eio_cli!" >2&
+    else
+        ${BPREFIX}echo "INSTALL-EIO: Installed eio_cli, see \"man eio_cli\" for useage"
+    fi
+fi
+if [ $LOAD_MODS -eq 1 ]
+    then
+    ${BPREFIX}echo "INSTALL-EIO: Loading EnhanceIO modules"
+    _LoadMods
+    if [ $? -eq 1 ]
+        then
+        ${BPREFIX}echo "INSTALL-EIO: Failed to load kernel modules!" >&2
+    else
+        ${BPREFIX}echo "INSTALL-EIO: Loaded EnhanceIO kernel modules"
+    fi
+fi
+if [ $CLEANUP -eq 1 ]
+    then
+    ${BPREFIX}echo "INSTALL-EIO: Cleaning up build files..."
+    _RunCleanup
+fi
+${BPREFIX}echo "INSTALL-EIO: Complete!"
+exit 0

--- a/Install.txt
+++ b/Install.txt
@@ -1,29 +1,123 @@
-Installation steps
+Installation
+------------
+
+EnhanceIO requires Linux running kernel 3.7 or higher along with the procfs virtual filesystem
+and udev utilities. The eio_cli utility requires Python2 version 2.6.6 or higher.
+
+Older versions of the Linux kernel or Python may work, but will not be suppoerted.
+
+
+Prerequisit
+-----------
+
+Building kernel modules from source requires that you have kernel development headers installed.
+
+See your distribution's documentation for what packages you need installed for kernel 
+development.
+
+
+Install-EIO
+-----------
+
+For convienience and simplicity, EnhanceIO can now be build and installed using the new
+Install-EIO script. It contains many useful options and saves a lot of time, especialy when
+building for multiple kernels. 
+
+Install Now:
+
+   To build and install EnhanceIO and it's utilities immediately on the current kernel, 
+   simply run:
+   
+   # ./Install-EIO
+   
+   This will build, install, and load the modules required by EnhanceIO, as well as installing
+   eio_cli and it's manual, and even clean up the files leftover by make. No further steps are
+   required.
+
+Install For Another Kernel:
+   
+   To build/install for another kernel run:
+   
+   # ./Install-EIO -k <KERNEL_VERSION>
+   
+   This will assume that eio_cli has already been installed and will skip its installation.
+   Installing eio_cli separately is covered below.
+   
+   It also assumes that you will not be building for the running kernel and will not load
+   modules for the running kernel.
+   Manualy loading modules is covered below.
+   
+Installing For Multiple Kernels:
+   
+   Install-EIO does not explicitly support building for multiple kernels. However it is
+   theoretically possible to do so using a shell loop.
+   
+   For example:
+   
+   # for i in $(ls /lib/modules); do ./Install-EIO -k $i; done
+   
+   This assumes that the required kernel headers are installed for all present kernels.
+   
+Installing eio_cli Separately:
+   
+   Installing eio_cli with Install-EIO is as easy as running:
+   
+   # ./Install-EIO install-cli
+   
+   This will only install eio_cli and it's manual.
+   
+Manual Cleanup:
+   
+   Install-EIO allows you to skip the build cleanup and run it later. To do this just run:
+   
+   # ./Install-EIO cleanup
+   
+   This will only reomve the files created by make after the build process.
+   
+Other Install-EIO Options:
+   
+   For other options suppoted by Install-EIO run:
+   
+   # ./Install-EIO --help
+
+
+Manual Installation
 -------------------
 
-Requirements
-Kernel version 3.7 onwards
-python 2.6.6 onwards
+If you feel the need to install EnhanceIO manualy, this is still an option.
 
-Run following commands as root
+Make and Make Install:
+   
+   To build and install the EnhanceIO modules run:
+   
+   # cd ./Driver/enhanceio
+   # make && make install
 
-1) eio_cli installation
-   > cp CLI/eio_cli /sbin/
-   > chmod 700 CLI/eio_cli	
-  
+Installing eio_cli:
+   
+   The best way to install the EnhanceIO utility is to use:
+   
+   # install -o root -g root -m 700 ./CLI/eio_cli /sbin/eio_cli
+   
+   The manual can be installed using:
+   
+   # install -o root -g root -m 644 ./CLI/eio_cli.8 /usr/share/man/man8/eio_cli.8
+   
+   This ensures the files are placed correctly with the correct owner, group, and permissions.
+   
+Loading Modules:
+   
+   Once the modules have been installed on the running kernel they can be loaded using:
+   
+   # modprode enhanceio
+   # modprode enhanceio_rand
+   # modprode enhanceio_fifo
+   # modprode enhanceio_lru
+   
+   Once the modules have been loaded you will be able to use eio_cli to create/modify caches.
+   
+   
+Notes
+-----
 
-2) Man page
-   Copy the  eio_cli.8 file under the man8 subdirectory of man directory (/usr/share/man/man8/).
-
-
-3) Driver installation
-
-   make && make install
-
-4) manually load modules by running
-   modprobe enhanceio_fifo
-   modprobe enhanceio_lru
-   modprobe enhanceio
-   You can now create enhanceio caches using the utility eio_cli. Please refer
-   to Documents/Persistence.txt for information about making a cache
-   configuration persistent across reboot.
+Caches created with eio_cli will be persistent by default. See ./Ducuments/Persistence.txt.


### PR DESCRIPTION
* Compatability for kernel versions >= 5.0

Use GET_KTIME instead of "do_gettimeofday", which has been removed.
Use TIME_STRUCT instead of "timeval" for use with GET_KTIME.
The word "time" looks weird now.

* Compatability for kernel versions >= 5.0

Changed "timeval" in cache_c to TIME_STRUCT as defined in compat.h

* Compatability for kernel versions >= 5.0

Changed "timeval" to TIME_STRUCT and "do_gettimeofday" to GET_KTIME in function "eio_post_io_callback" for comatability.

* Update eio.h

* Update eio.h

* Added Simplified Installation Script

Added Install-EIO script to simplify the process of deploying from source.

* Complete Rewrite of Installation Instructions

There's basically nothing left of the original file. I rewrote it to show more detail, but mostly to give instructions for Install-EIO.

* Fixed pemissions on Install-EIO.

* Fixed Some Typos